### PR TITLE
Fixed empty contract data

### DIFF
--- a/functions/contracts.php
+++ b/functions/contracts.php
@@ -62,6 +62,10 @@ function fetch_contracts() {
 			continue;
 		}
 
+		if ( ! isset($contract->releases[0]->contracts) ) {
+			continue;
+		}
+
 		// insert the contracts into the table
 		$wpdb->insert('ocp_contracts', [
 			'ocid' => $contract_meta->id,


### PR DESCRIPTION
Skips DB insert statements when the returned data contains no contract data